### PR TITLE
Add sql migration and optimize plugin for big servers

### DIFF
--- a/src/main/java/dev/unnm3d/rediseconomy/RedisEconomyPlugin.java
+++ b/src/main/java/dev/unnm3d/rediseconomy/RedisEconomyPlugin.java
@@ -92,8 +92,8 @@ public final class RedisEconomyPlugin extends JavaPlugin {
         this.getLogger().info("Hooked into Vault!");
 
         if (settings().migrationEnabled) {
-            scheduler.runTaskLater(() ->
-                    currenciesManager.migrateFromOfflinePlayers(getServer().getOfflinePlayers()), 100L);
+            scheduler.runTaskLaterAsynchronously(() ->
+                    currenciesManager.migrate(), 100L);
         } else {
             currenciesManager.loadDefaultCurrency(this.vaultPlugin);
         }

--- a/src/main/java/dev/unnm3d/rediseconomy/config/Settings.java
+++ b/src/main/java/dev/unnm3d/rediseconomy/config/Settings.java
@@ -23,6 +23,9 @@ public class Settings {
     @Comment({"if true, migrates the bukkit offline uuids accounts to the default RedisEconomy currency",
             "During the migration, the plugin will be disabled. Restart all RedisEconomy instances after the migration."})
     public boolean migrationEnabled = false;
+    @Comment({"if enabled, the plugin will migrate economy data from sql database",
+            "During the migration, the plugin will be disabled. Restart all RedisEconomy instances after the migration."})
+    public SqlMigrateSettings migrationSql = new SqlMigrateSettings(false, "com.mysql.cj.jdbc.Driver", "jdbc:mysql://localhost:3306/database?useSSL=false", "root", "password", "economy", "name", "uuid", "money");
     @Comment("Allow paying with percentage (ex: /pay player 10% sends 'player' 10% of the sender balance)")
     public boolean allowPercentagePayments = true;
     @Comment({"Leave password or user empty if you don't have a password or user",
@@ -52,4 +55,7 @@ public class Settings {
     public record RedisSettings(String host, int port, String user, String password, int database, int timeout,
                                 String clientName) {
     }
+
+    public record SqlMigrateSettings(boolean enabled, String driver, String url, String username, String password, String table, String nameColumn, String uuidColumn, String moneyColumn) {
+    };
 }

--- a/src/main/java/dev/unnm3d/rediseconomy/currency/CurrenciesManager.java
+++ b/src/main/java/dev/unnm3d/rediseconomy/currency/CurrenciesManager.java
@@ -54,8 +54,8 @@ public class CurrenciesManager extends RedisEconomyAPI implements Listener {
         this.configManager = configManager;
         this.currencies = new HashMap<>();
         try {
-            this.nameUniqueIds = loadRedisNameUniqueIds().toCompletableFuture().get(1, TimeUnit.SECONDS);
-            this.lockedAccounts = loadLockedAccounts().toCompletableFuture().get(1, TimeUnit.SECONDS);
+            this.nameUniqueIds = loadRedisNameUniqueIds().toCompletableFuture().get(10, TimeUnit.SECONDS);
+            this.lockedAccounts = loadLockedAccounts().toCompletableFuture().get(10, TimeUnit.SECONDS);
         } catch (InterruptedException | ExecutionException | TimeoutException e) {
             throw new RuntimeException(e);
         }

--- a/src/main/java/dev/unnm3d/rediseconomy/currency/Currency.java
+++ b/src/main/java/dev/unnm3d/rediseconomy/currency/Currency.java
@@ -529,7 +529,7 @@ public class Currency implements Economy {
         return new EconomyResponse(amount, getBalance(playerUUID), EconomyResponse.ResponseType.SUCCESS, null);
     }
 
-    void updateAccountLocal(@NotNull UUID uuid, @Nullable String playerName, double balance) {
+    public void updateAccountLocal(@NotNull UUID uuid, @Nullable String playerName, double balance) {
         if (playerName != null)
             currenciesManager.updateNameUniqueId(playerName, uuid);
         accounts.put(uuid, balance);

--- a/src/main/java/dev/unnm3d/rediseconomy/currency/CurrencyMigration.java
+++ b/src/main/java/dev/unnm3d/rediseconomy/currency/CurrencyMigration.java
@@ -1,0 +1,34 @@
+package dev.unnm3d.rediseconomy.currency;
+
+import dev.unnm3d.rediseconomy.RedisEconomyPlugin;
+import org.bukkit.Bukkit;
+
+public abstract class CurrencyMigration {
+
+    protected final RedisEconomyPlugin plugin;
+    protected final Currency currency;
+
+    public CurrencyMigration(RedisEconomyPlugin plugin, Currency currency) {
+        this.plugin = plugin;
+        this.currency = currency;
+    }
+
+    public abstract String getProvider();
+
+    protected abstract boolean setup();
+
+    protected abstract void start();
+
+    public void migrate() {
+        if (!setup()) {
+            return;
+        }
+
+        Bukkit.getConsoleSender().sendMessage("[RedisEconomy] §aMigrating from " + getProvider() + "...");
+
+        start();
+
+        Bukkit.getConsoleSender().sendMessage("[RedisEconomy] §aMigration completed!");
+        Bukkit.getConsoleSender().sendMessage("[RedisEconomy] §aRestart the server to apply the changes.");
+    }
+}

--- a/src/main/java/dev/unnm3d/rediseconomy/currency/migration/OfflinePlayerCurrencyMigration.java
+++ b/src/main/java/dev/unnm3d/rediseconomy/currency/migration/OfflinePlayerCurrencyMigration.java
@@ -1,0 +1,63 @@
+package dev.unnm3d.rediseconomy.currency.migration;
+
+import dev.unnm3d.rediseconomy.RedisEconomyPlugin;
+import dev.unnm3d.rediseconomy.currency.Currency;
+import dev.unnm3d.rediseconomy.currency.CurrencyMigration;
+import io.lettuce.core.ScoredValue;
+import net.milkbowl.vault.economy.Economy;
+import org.bukkit.Bukkit;
+import org.bukkit.OfflinePlayer;
+import org.bukkit.plugin.RegisteredServiceProvider;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+public class OfflinePlayerCurrencyMigration extends CurrencyMigration {
+
+    RegisteredServiceProvider<Economy> existentProvider;
+
+    public OfflinePlayerCurrencyMigration(RedisEconomyPlugin plugin, Currency currency) {
+        super(plugin, currency);
+    }
+
+    @Override
+    public String getProvider() {
+        return existentProvider.getProvider().getName();
+    }
+
+    @Override
+    protected boolean setup() {
+        existentProvider = plugin.getServer().getServicesManager().getRegistration(Economy.class);
+        if (existentProvider == null) {
+            plugin.getLogger().severe("Vault economy provider not found!");
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    protected void start() {
+        OfflinePlayer[] offlinePlayers = Bukkit.getOfflinePlayers();
+
+        final List<ScoredValue<String>> balances = new ArrayList<>();
+        final Map<String, String> nameUniqueIds = new HashMap<>();
+        for (int i = 0; i < offlinePlayers.length; i++) {
+            final OfflinePlayer offlinePlayer = offlinePlayers[i];
+            try {
+                double bal = existentProvider.getProvider().getBalance(offlinePlayer);
+                balances.add(ScoredValue.just(bal, offlinePlayer.getUniqueId().toString()));
+                if (offlinePlayer.getName() != null)
+                    nameUniqueIds.put(offlinePlayer.getName(), offlinePlayer.getUniqueId().toString());
+                currency.updateAccountLocal(offlinePlayer.getUniqueId(), offlinePlayer.getName() == null ? offlinePlayer.getUniqueId().toString() : offlinePlayer.getName(), bal);
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+            if (i % 1000 == 0) {
+                plugin.getLogger().info("Progress: " + i + "/" + offlinePlayers.length);
+            }
+        }
+        currency.updateBulkAccountsCloudCache(balances, nameUniqueIds);
+    }
+}

--- a/src/main/java/dev/unnm3d/rediseconomy/currency/migration/SqlCurrencyMigration.java
+++ b/src/main/java/dev/unnm3d/rediseconomy/currency/migration/SqlCurrencyMigration.java
@@ -1,0 +1,96 @@
+package dev.unnm3d.rediseconomy.currency.migration;
+
+import dev.unnm3d.rediseconomy.RedisEconomyPlugin;
+import dev.unnm3d.rediseconomy.config.Settings;
+import dev.unnm3d.rediseconomy.currency.Currency;
+import dev.unnm3d.rediseconomy.currency.CurrencyMigration;
+import io.lettuce.core.ScoredValue;
+
+import java.sql.*;
+import java.util.*;
+import java.util.logging.Level;
+
+public class SqlCurrencyMigration extends CurrencyMigration {
+
+    private Settings.SqlMigrateSettings sql;
+    private Connection connection;
+
+    public SqlCurrencyMigration(RedisEconomyPlugin plugin, Currency currency) {
+        super(plugin, currency);
+    }
+
+    @Override
+    public String getProvider() {
+        return "SQL DATABASE";
+    }
+
+    @Override
+    protected boolean setup() {
+        sql = plugin.getConfigManager().getSettings().migrationSql;
+        try {
+            Class.forName(sql.driver());
+        } catch (ClassNotFoundException e) {
+            plugin.getLogger().warning("Cannot find SQL driver class: " + sql.driver());
+        }
+        try {
+            connection = DriverManager.getConnection(sql.url(), sql.username(), sql.password());
+            return true;
+        } catch (Throwable t) {
+            plugin.getLogger().log(Level.SEVERE, t, () -> "Cannot connect to SQL database");
+            return false;
+        }
+    }
+
+    @Override
+    protected void start() {
+        final List<ScoredValue<String>> balances = new ArrayList<>();
+        final Map<String, String> nameUniqueIds = new HashMap<>();
+
+        try (PreparedStatement count = connection.prepareStatement("SELECT COUNT(*) FROM `" + sql.table() + "`"); PreparedStatement stmt = connection.prepareStatement("SELECT ALL * FROM `" + sql.table() + "`")) {
+            String total = "ALL";
+            try {
+                ResultSet resultSet = count.executeQuery();
+
+                if (resultSet.next()) {
+                    int rowCount = resultSet.getInt(1);
+                    total = String.valueOf(rowCount);
+                }
+            } catch (SQLException ignored) { }
+
+            plugin.getLogger().info("Total lines: " + total);
+
+            final ResultSet result = stmt.executeQuery();
+            int i = 0;
+            while (result.next()) {
+                i++;
+                try {
+                    final String name = result.getString(sql.nameColumn());
+                    final String uuid = result.getString(sql.uuidColumn());
+                    if (uuid == null) continue;
+                    final double money = result.getDouble(sql.moneyColumn());
+                    if (money == 0) continue;
+
+                    balances.add(ScoredValue.just(money, uuid));
+                    if (name != null)
+                        nameUniqueIds.put(name, uuid);
+                    currency.updateAccountLocal(UUID.fromString(uuid), name == null ? uuid : name, money);
+                } catch (Exception e) {
+                    e.printStackTrace();
+                }
+
+                if (i % 1000 == 0) {
+                    plugin.getLogger().info("Progress: " + i + "/" + total);
+                }
+            }
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+
+        try {
+            connection.close();
+        } catch (SQLException e) {
+            e.printStackTrace();
+        }
+        currency.updateBulkAccountsCloudCache(balances, nameUniqueIds);
+    }
+}


### PR DESCRIPTION
I found multiple problems using the plugin, so I added some changes to fix them.

### SQL migration
Instead of offline player migration, this concept obtain data directly from a SQL database.
Some plugins like MySQLPlayerDataBridge did not allow me to migrate the data because it did not exist for some players when using Vault API.

### Big servers data handling
For example, one of my server modes have more than 350.000 accounts, so I extended the name loading timeout and also created an optimized backup command.
Previously, using `/backup-economy` the plugin took 45 minutes to save accounts into file, now it took no more than 5 seconds.