### PR TITLE
Update .gitignore for Gradle

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -111,3 +111,17 @@ buildNumber.properties
 
 # Common working directory
 run/
+
+.gradle
+build/
+
+# Ignore Gradle GUI config
+gradle-app.setting
+
+# Cache of project
+.gradletasknamecache
+
+**/build/
+
+# Avoid ignoring Gradle wrapper jar file (.jar files are usually ignored)
+!gradle-wrapper.jar


### PR DESCRIPTION
Currently, Git will try to add some Gradle files that should actually be ignored after Building the project.

This fixes that.