### PR TITLE
Add singular and plural currency name placeholders

### DIFF
--- a/src/main/java/dev/unnm3d/rediseconomy/utils/PlaceholderAPIHook.java
+++ b/src/main/java/dev/unnm3d/rediseconomy/utils/PlaceholderAPIHook.java
@@ -99,6 +99,8 @@ public class PlaceholderAPIHook extends PlaceholderExpansion implements Relation
     // %rediseco_bal_formatted_shorthand_<currency>%
     // %rediseco_top_1_name_shorthand_<currency>%
     // %rediseco_top_1_bal_shorthand_<currency>%
+    // %rediseco_singular_<currency>%
+    // %rediseco_plural_<currency>%
     @Override
     public String onRequest(OfflinePlayer player, String params) {
         List<String> splitted = List.of(params.split("_"));
@@ -111,6 +113,14 @@ public class PlaceholderAPIHook extends PlaceholderExpansion implements Relation
             return parseParams(balance, splitted, currency);
 
         }
+
+        if (splitted.get(0).equals("singular")) {
+            return currency.getCurrencySingular();
+        }
+        if (splitted.get(0).equals("plural")) {
+            return currency.getCurrencyPlural();
+        }
+
         updatePlaceholdersCache();
 
         switch (splitted.get(0)) {


### PR DESCRIPTION
Add support for retrieving singular and plural currency names through PlaceholderAPI. This allows server owners to use `%rediseco_singular_<currency>%` and `%rediseco_plural_<currency>%`  in their messages and UIs to display the appropriate currency name form.